### PR TITLE
Patch bug in html-inputs plugin

### DIFF
--- a/src/html-inputs/__tests__/html__hook--options.test.ts
+++ b/src/html-inputs/__tests__/html__hook--options.test.ts
@@ -133,14 +133,24 @@ test('always parse HTML files', () => {
 
   expect(result).toEqual({
     input: {
-      background:
-        '/home/jack/Documents/Rollup/rollup-plugin-chrome-extension/__fixtures__/extensions/basic/background.js',
-      options1: '__fixtures__/extensions/basic/options1.js',
-      options2: '__fixtures__/extensions/basic/options2.jsx',
-      options3: '__fixtures__/extensions/basic/options3.ts',
-      options4: '__fixtures__/extensions/basic/options4.tsx',
-      'popup/popup':
-        '__fixtures__/extensions/basic/popup/popup.js',
+      background: expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/background\.js$/,
+      ),
+      options1: expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/options1\.js$/,
+      ),
+      options2: expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/options2\.jsx$/,
+      ),
+      options3: expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/options3\.ts$/,
+      ),
+      options4: expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/options4\.tsx$/,
+      ),
+      'popup/popup': expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/popup\/popup\.js$/,
+      ),
     },
   })
 })
@@ -153,14 +163,24 @@ test.skip('if cache.input exists, skip parsing html files', () => {
   // FIXME: remove html files from options
   expect(result).toEqual({
     input: {
-      background:
-        '/home/jack/Documents/Rollup/rollup-plugin-chrome-extension/__fixtures__/extensions/basic/background.js',
-      options1: '__fixtures__/extensions/basic/options1.js',
-      options2: '__fixtures__/extensions/basic/options2.jsx',
-      options3: '__fixtures__/extensions/basic/options3.ts',
-      options4: '__fixtures__/extensions/basic/options4.tsx',
-      'popup/popup':
-        '__fixtures__/extensions/basic/popup/popup.js',
+      background: expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/background\.js$/,
+      ),
+      options1: expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/options1\.js$/,
+      ),
+      options2: expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/options2\.jsx$/,
+      ),
+      options3: expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/options3\.ts$/,
+      ),
+      options4: expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/options4\.tsx$/,
+      ),
+      'popup/popup': expect.stringMatching(
+        /__fixtures__\/extensions\/basic\/popup\/popup\.js$/,
+      ),
     },
   })
 })

--- a/src/html-inputs/__tests__/html__hook--options.test.ts
+++ b/src/html-inputs/__tests__/html__hook--options.test.ts
@@ -126,15 +126,27 @@ test('caches correct inputs & assets', () => {
   expect(cache.scripts).toEqual([assetJs].map(getRelative))
 })
 
-test('if cache.input exists, do nothing', () => {
+test.skip('if cache.input exists, skip parsing html files', () => {
   cache.input = [optionsJs]
 
   const result = plugin.options.call(context, options)
 
-  expect(result).toBe(options)
+  // FIXME: remove html files from options
+  expect(result).toEqual({
+    input: {
+      background:
+        '/home/jack/Documents/Rollup/rollup-plugin-chrome-extension/__fixtures__/extensions/basic/background.js',
+      options1: '__fixtures__/extensions/basic/options1.js',
+      options2: '__fixtures__/extensions/basic/options2.jsx',
+      options3: '__fixtures__/extensions/basic/options3.ts',
+      options4: '__fixtures__/extensions/basic/options4.tsx',
+      'popup/popup':
+        '__fixtures__/extensions/basic/popup/popup.js',
+    },
+  })
 })
 
-test('if no input has no html, do nothing', () => {
+test('if input has no html, do nothing', () => {
   const options = { input: [optionsJs] }
 
   const result = plugin.options.call(context, options)

--- a/src/html-inputs/__tests__/html__hook--options.test.ts
+++ b/src/html-inputs/__tests__/html__hook--options.test.ts
@@ -143,6 +143,7 @@ test('if no input has no html, do nothing', () => {
 })
 
 test('Throws with invalid input type', () => {
+  // eslint-disable-next-line
   const options = { input: () => {} }
 
   const call = () => {

--- a/src/html-inputs/__tests__/html__hook--options.test.ts
+++ b/src/html-inputs/__tests__/html__hook--options.test.ts
@@ -126,6 +126,25 @@ test('caches correct inputs & assets', () => {
   expect(cache.scripts).toEqual([assetJs].map(getRelative))
 })
 
+test('always parse HTML files', () => {
+  cache.input = [optionsJs, popupHtml]
+
+  const result = plugin.options.call(context, options)
+
+  expect(result).toEqual({
+    input: {
+      background:
+        '/home/jack/Documents/Rollup/rollup-plugin-chrome-extension/__fixtures__/extensions/basic/background.js',
+      options1: '__fixtures__/extensions/basic/options1.js',
+      options2: '__fixtures__/extensions/basic/options2.jsx',
+      options3: '__fixtures__/extensions/basic/options3.ts',
+      options4: '__fixtures__/extensions/basic/options4.tsx',
+      'popup/popup':
+        '__fixtures__/extensions/basic/popup/popup.js',
+    },
+  })
+})
+
 test.skip('if cache.input exists, skip parsing html files', () => {
   cache.input = [optionsJs]
 

--- a/src/html-inputs/index.ts
+++ b/src/html-inputs/index.ts
@@ -66,7 +66,8 @@ export default function htmlInputs(
     options(options) {
       // Skip if cache.input exists
       // cache is dumped in watchChange hook
-      if (cache.input.length) return options
+      // FIXME: skip HTML parsing if dependencies have not changed
+      // if (cache.input.length) return options
 
       // Parse options.input to array
       let input: string[]
@@ -108,6 +109,8 @@ export default function htmlInputs(
         )
       }
 
+      // TODO: simply remove HTML files from options.input
+      // - Parse HTML and emit chunks and assets in buildStart
       return {
         ...options,
         input: cache.input.reduce(


### PR DESCRIPTION
Temporarily do not cache html parsing results